### PR TITLE
fix: avoid matching IPs in parts of URL

### DIFF
--- a/util/parse-ip.js
+++ b/util/parse-ip.js
@@ -4,7 +4,7 @@ const QQWry = require('lib-qqwry');
 const { qqwryDataPath } = require('./const');
 const { searchIP } = new QQWry(true, qqwryDataPath);
 
-const ipv4Regex = /(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}/gm;
+const ipv4Regex = /(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}(?=[\s$])/gm;
 
 const parseIp = str => {
   return str.replace(ipv4Regex, match => {


### PR DESCRIPTION
In some cases we don't really want to check an IP-like addresses (for example, when we are doing RDNS queries). This PR checks if the IP address is not part of a longer string, and discards it if it is.

```
; <<>> DiG 9.16.7 <<>> -x 1.2.4.8 [中国 CNNIC 权威云解析 (CDNS.CN) 全球 Anycast 节点]
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 38009
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;8.4.2.1 [美国 科罗拉多州布隆菲尔德市 Level 3 通信股份有限公司].in-addr.arpa.		IN	PTR

;; ANSWER SECTION:
8.4.2.1 [美国 科罗拉多州布隆菲尔德市 Level 3 通信股份有限公司].in-addr.arpa.	21599	IN	PTR	public1.sdns.cn.

;; Query time: 118 msec
;; SERVER: 127.0.0.1 [局域网 IP]#53(127.0.0.1 [局域网 IP])
;; WHEN: Tue Oct 20 09:34:12 CST 2020
;; MSG SIZE  rcvd: 78
```