### PR TITLE
修正下载缓冲区读取

### DIFF
--- a/util/qqwryUpdate.js
+++ b/util/qqwryUpdate.js
@@ -51,9 +51,12 @@ const get_qqwry = showBar => getURLFile('https://qqwry.mirror.noc.one/QQWry.Dat'
 
 async function getLastInfo() {
   const copywrite = await get_copywrite();
-  copywrite.read(24);
-  const version = gbkDecode(copywrite.read(64)).replace(/\0/g, '');
-  return version;
+  let buf = Buffer.alloc(0)
+  for await (const data of copywrite) {
+    buf = Buffer.concat([buf, data])
+  }
+  return gbkDecode(buf.slice(24, 64))
+    .replace(/\0/g, '');
 }
 
 async function qqwryUpdate(dataPath) {


### PR DESCRIPTION
fix `nali update`
```
嗷呜，出现错误惹! Cannot read property 'length' of null
TypeError: Cannot read property 'length' of null
    at decode (/Users/bangbang93/n/lib/node_modules/nali-cli/node_modules/gbk.js/src/gbk.js:6:30)
    at getLastInfo (/Users/bangbang93/n/lib/node_modules/nali-cli/util/qqwryUpdate.js:55:19)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async main (/Users/bangbang93/n/lib/node_modules/nali-cli/lib/nali-update.js:25:21)
```
stream的读取方式不对，直接read(24)和read(64)，由于网络情况不同，有可能会读到空流，返回null